### PR TITLE
Fix for PolygonContainment checking methods.

### DIFF
--- a/Nucleus/Nucleus/Geometry/Intersect.cs
+++ b/Nucleus/Nucleus/Geometry/Intersect.cs
@@ -1321,7 +1321,7 @@ namespace Nucleus.Geometry
                 if (segEnd.X < rayStart.X) return false; // Segment to the left!
                 // Ray start falls within segment bounds - need to do additional check on whether
                 // ray start is to the right or left
-                else if (((segStart.Y >= rayStart.Y && segEnd.Y < rayStart.Y)
+                else if (((segStart.Y > rayStart.Y && segEnd.Y < rayStart.Y)
                 || (segStart.Y < rayStart.Y && segEnd.Y >= rayStart.Y)))
                 {
                     double dist = segStart.X + (segEnd.X - segStart.X) * ((rayStart.Y - segStart.Y) / (segEnd.Y - segStart.Y)) - rayStart.X;
@@ -1331,11 +1331,11 @@ namespace Nucleus.Geometry
                         return true;
                     }
                 }
-                 return false;
+                return false;
             }
             else if (segEnd.X < rayStart.X) //Ray start falls within segment bounds
             {
-                if (((segStart.Y >= rayStart.Y && segEnd.Y < rayStart.Y)
+                if (((segStart.Y > rayStart.Y && segEnd.Y < rayStart.Y)
                 || (segStart.Y < rayStart.Y && segEnd.Y >= rayStart.Y)))
                 {
                     double dist = segStart.X + (segEnd.X - segStart.X) * ((rayStart.Y - segStart.Y) / (segEnd.Y - segStart.Y)) - rayStart.X;
@@ -1348,9 +1348,8 @@ namespace Nucleus.Geometry
                 return false;
             }
             //Segment is to the right of ray start
-            else if ((segStart.Y >= rayStart.Y && segEnd.Y < rayStart.Y)
-                || (segStart.Y <= rayStart.Y && segEnd.Y > rayStart.Y)
-                || (rayStart.Y == segStart.Y && rayStart.Y == segEnd.Y))
+            else if ((segStart.Y > rayStart.Y && segEnd.Y < rayStart.Y)
+                || (segStart.Y <= rayStart.Y && segEnd.Y > rayStart.Y))
             {
                 //if (segStart.X == rayStart.X && segEnd.X == rayStart.X) onLine = true;
                 return true;


### PR DESCRIPTION
XRayLineSegmentXYCheck was producing incorrect results when
intersecting with the start or end of a polygon edge segment.

This check now ignores any segments that are parallel and aligned with the ray.
Also now when checking the point where 2 segments join, only segments above the ray will be counted and any below will be ignored.

modified:   Nucleus/Nucleus/Geometry/Intersect.cs