### PR TITLE
Fix for PolyCurve offset method

### DIFF
--- a/Nucleus/Nucleus/Geometry/Curve.cs
+++ b/Nucleus/Nucleus/Geometry/Curve.cs
@@ -2167,6 +2167,20 @@ namespace Nucleus.Geometry
         public IList<Curve> SelfIntersectionXYLoopsAlignedWith(Curve alignedWith)
         {
             var loops = SelfIntersectionXYLoops();
+            foreach (var loop in loops)
+            {
+                if (alignedWith.IsClockwiseXY() == loop.IsClockwiseXY() && alignedWith.Closed && !loop.Closed)
+                {
+                    if (loop is PolyLine polyline)
+                    {
+                        polyline.Close();
+                    }
+                    else if (loop is PolyCurve polycurve)
+                    {
+                        polycurve.Close();
+                    }
+                }
+            }
             loops.RemoveInvertedCurvesXY(alignedWith);
             return loops;
         }


### PR DESCRIPTION
Offset method sometimes returns null when offsetting a PolyCurve outwards. 
Fixed by ensuring that the offset curve is closed if the input curve was originally closed.

modified:   Nucleus/Nucleus/Geometry/Curve.cs