### PR TITLE
Fix indices exception when converting from netDXF to a Nucleus Mesh

### DIFF
--- a/Nucleus/Nucleus.DXF/DXFReader.cs
+++ b/Nucleus/Nucleus.DXF/DXFReader.cs
@@ -163,8 +163,6 @@ namespace Nucleus.DXF
                 result.Add(FromDXF.Convert(mesh));
             }
 
-            doc.Solids
-
             // Text
             foreach (netDxf.Entities.Text text in doc.Texts)
             {

--- a/Nucleus/Nucleus.DXF/FromDXF.cs
+++ b/Nucleus/Nucleus.DXF/FromDXF.cs
@@ -291,7 +291,7 @@ namespace Nucleus.DXF
             for (int i = 0; i < mesh.Faces.Count; i++)
             {
                 var indices = mesh.Faces[i];
-                indices.AddToAll(-1); // Make zero-indexed
+                if (indices.Min() == 1) indices.AddToAll(-1); // Make zero-indexed
                 result.AddFace(indices);
             }
             return result;
@@ -315,12 +315,12 @@ namespace Nucleus.DXF
             {
                 var face = mesh.Faces[i];
                 var indices = face.VertexIndexes.ToInts();
-                indices.AddToAll(-1); // Make zero-indexed
+                if (indices.Min() == 1) indices.AddToAll(-1); // Make zero-indexed
                 result.AddFace(indices);
             }
             return result;
         }
-6j
+
         /// <summary>
         /// Convert a netDXF entity to a Nucleus geometry object
         /// </summary>


### PR DESCRIPTION
Converted face indices sometimes start at -1 but should be 0. 
Fixed by checking whether indices are already zero-indexed before converting them.

modified:   Nucleus/Nucleus.DXF/DXFReader.cs
modified:   Nucleus/Nucleus.DXF/FromDXF.cs