### PR TITLE
Fix for the PolygonContainmentXY method in Vector and IPosition

### DIFF
--- a/Nucleus/Nucleus/Geometry/IPosition.cs
+++ b/Nucleus/Nucleus/Geometry/IPosition.cs
@@ -98,8 +98,10 @@ namespace Nucleus.Geometry
         /// Check for containment of a point within a polygon with these vertices on the XY plane
         /// </summary>
         /// <param name="point">The point to test for containment</param>
+        /// <param name="onEdgeIsInside">If true, a point located exactly on 
+        /// the edge of the polygon will be treated as a being contained.</param>
         /// <returns>True if the point is inside (or on) the polygon, else false.</returns>
-        public static bool PolygonContainmentXY<T>(this IList<T> polygon, Vector point) where T:IPosition
+        public static bool PolygonContainmentXY<T>(this IList<T> polygon, Vector point, bool onEdgeIsInside = true) where T:IPosition
         {
             if (polygon.Count > 2)
             {
@@ -111,13 +113,13 @@ namespace Nucleus.Geometry
                     Vector nextPoint = polygon[i].Position;
                     if (Intersect.XRayLineSegmentXYCheck(ref point, ref lastPoint, ref nextPoint, out onLine))
                         count++;
-                    if (onLine) return true; //TODO: Review
+                    if (onLine) return onEdgeIsInside;
                     lastPoint = nextPoint;
                 }
                 Vector startPoint = polygon[0].Position;
                 if (Intersect.XRayLineSegmentXYCheck(ref point, ref lastPoint, ref startPoint, out onLine))
                     count++;
-                if (onLine) return true; //TODO: Review
+                if (onLine) return onEdgeIsInside;
                 return count.IsOdd();
             }
             else return false;

--- a/Nucleus/Nucleus/Geometry/Intersect.cs
+++ b/Nucleus/Nucleus/Geometry/Intersect.cs
@@ -1322,13 +1322,19 @@ namespace Nucleus.Geometry
                 if (segEnd.X < rayStart.X) return false; // Segment to the left!
                 // Ray start falls within segment bounds - need to do additional check on whether
                 // ray start is to the right or left
-                else if (((segStart.Y > rayStart.Y && segEnd.Y < rayStart.Y)
-                || (segStart.Y < rayStart.Y && segEnd.Y >= rayStart.Y)))
+                else if (segStart.Y == rayStart.Y && segEnd.Y == rayStart.Y)
+                {
+                    onLine = true;
+                    return true;
+                }
+                else if ((segStart.Y >= rayStart.Y && segEnd.Y <= rayStart.Y)
+                    || (segStart.Y <= rayStart.Y && segEnd.Y >= rayStart.Y))
                 {
                     double dist = segStart.X + (segEnd.X - segStart.X) * ((rayStart.Y - segStart.Y) / (segEnd.Y - segStart.Y)) - rayStart.X;
+                    if (dist.IsTiny()) dist = 0;
                     if (dist >= 0)
                     {
-                        //if (dist == 0) onLine = true;
+                        if (dist == 0) onLine = true;
                         return true;
                     }
                 }
@@ -1336,23 +1342,29 @@ namespace Nucleus.Geometry
             }
             else if (segEnd.X < rayStart.X) //Ray start falls within segment bounds
             {
-                if (((segStart.Y > rayStart.Y && segEnd.Y < rayStart.Y)
-                || (segStart.Y < rayStart.Y && segEnd.Y >= rayStart.Y)))
+                if (segStart.Y == rayStart.Y && segEnd.Y == rayStart.Y)
+                {
+                    onLine = true;
+                    return true;
+                }
+                else if ((segStart.Y >= rayStart.Y && segEnd.Y <= rayStart.Y)
+                    || (segStart.Y <= rayStart.Y && segEnd.Y >= rayStart.Y))
                 {
                     double dist = segStart.X + (segEnd.X - segStart.X) * ((rayStart.Y - segStart.Y) / (segEnd.Y - segStart.Y)) - rayStart.X;
+                    if (dist.IsTiny()) dist = 0;
                     if (dist >= 0)
                     {
-                        //if (dist == 0) onLine = true;
+                        if (dist == 0) onLine = true;
                         return true;
                     }
                 }
                 return false;
             }
             //Segment is to the right of ray start
-            else if ((segStart.Y > rayStart.Y && segEnd.Y < rayStart.Y)
-                || (segStart.Y <= rayStart.Y && segEnd.Y > rayStart.Y))
+            else if ((segStart.Y >= rayStart.Y && segEnd.Y <= rayStart.Y)
+                || (segStart.Y <= rayStart.Y && segEnd.Y >= rayStart.Y))
             {
-                //if (segStart.X == rayStart.X && segEnd.X == rayStart.X) onLine = true;
+                if (segStart.X == rayStart.X && segEnd.X == rayStart.X) onLine = true;
                 return true;
             }
             else return false;

--- a/Nucleus/Nucleus/Geometry/Vector.cs
+++ b/Nucleus/Nucleus/Geometry/Vector.cs
@@ -1900,28 +1900,30 @@ namespace Nucleus.Geometry
         /// Check for containment of a point within a polygon with these vertices on the XY plane
         /// </summary>
         /// <param name="point">The point to test for containment</param>
+        /// <param name="onEdgeIsInside">If true, a point located exactly on 
+        /// the edge of the polygon will be treated as being contained.</param>
         /// <returns>True if the point is inside (or on) the polygon, else false.</returns>
         /// <remarks>This is a copy of the IPosition list extension method of the same name.
         /// Changes made to one must be manually adapted to the other.</remarks>
-        public static bool PolygonContainmentXY(this IList<Vector> polygon, Vector point)
+        public static bool PolygonContainmentXY(this IList<Vector> polygon, Vector point, bool onEdgeIsInside = true)
         {
             if (polygon.Count > 2)
             {
                 int count = 0;
                 Vector lastPoint = polygon[0];
-                bool onLine = false;
+                bool onEdge = false;
                 for (int i = 1; i < polygon.Count; i++)
                 {
                     Vector nextPoint = polygon[i];
-                    if (Intersect.XRayLineSegmentXYCheck(ref point, ref lastPoint, ref nextPoint, out onLine))
+                    if (Intersect.XRayLineSegmentXYCheck(ref point, ref lastPoint, ref nextPoint, out onEdge))
                         count++;
-                    if (onLine) return true; //TODO: Review
+                    if (onEdge) return onEdgeIsInside;
                     lastPoint = nextPoint;
                 }
                 Vector startPoint = polygon[0];
-                if (Intersect.XRayLineSegmentXYCheck(ref point, ref lastPoint, ref startPoint, out onLine))
+                if (Intersect.XRayLineSegmentXYCheck(ref point, ref lastPoint, ref startPoint, out onEdge))
                     count++;
-                if (onLine) return true; //TODO: Review
+                if (onEdge) return onEdgeIsInside;
                 return count.IsOdd();
             }
             else return false;


### PR DESCRIPTION
Fixes some cases where the test point was directly on the polygon boundary or where the xray was aligned with a polygon edge. Also now allows some tolerance where a point is within a tiny distance of the polygon boundary.

modified:   Nucleus/Nucleus/Geometry/IPosition.cs
modified:   Nucleus/Nucleus/Geometry/Intersect.cs
modified:   Nucleus/Nucleus/Geometry/Vector.cs